### PR TITLE
Using os.path.expanduser to allow paths such as ~/test.png

### DIFF
--- a/dankcli/__main__.py
+++ b/dankcli/__main__.py
@@ -23,7 +23,8 @@ blackColor = "rgb(0, 0, 0)"
 
 # Check if specified image exists
 try:
-    img = Image.open(args.img)
+    img_path = os.path.expanduser(args.img)
+    img = Image.open(img_path)
 except Exception as e:
     print("Specified image doesn't exist or can't be opened")
     sys.exit(2)


### PR DESCRIPTION
Came across an issue where I couldn't use the path '~/Downloads/test.png' because Image.open() doesn't expand the user home dir symbol. Adding the use of [os.path.expanduser](https://docs.python.org/3/library/os.path.html#os.path.expanduser) keeps all the previous path functionality, but also enables the use of the users home dir as a valid path. 